### PR TITLE
Fix LitElement Imports

### DIFF
--- a/button-entity-row.js
+++ b/button-entity-row.js
@@ -1,4 +1,6 @@
-import { LitElement, html, css } from "https://unpkg.com/lit-element@2.0.1/lit-element.js?module"
+const LitElement = Object.getPrototypeOf(customElements.get("hui-view"))
+const html = LitElement.prototype.html
+const css = LitElement.prototype.css
 
 class ButtonEntityRow extends LitElement {
   static get properties() {
@@ -86,16 +88,16 @@ class ButtonEntityRow extends LitElement {
         let button =
           typeof item === "string"
             ? {
-              entityId: item,
-              icon: undefined,
-              stateIcons: undefined,
-              stateStyles: undefined,
-              stateIconStyles: undefined,
-              style: undefined,
-              iconStyle: undefined,
-              name: undefined,
-              service: undefined,
-              serviceData: undefined
+                entityId: item,
+                icon: undefined,
+                stateIcons: undefined,
+                stateStyles: undefined,
+                stateIconStyles: undefined,
+                style: undefined,
+                iconStyle: undefined,
+                name: undefined,
+                service: undefined,
+                serviceData: undefined
               }
             : {
                 entityId: item.entity,


### PR DESCRIPTION
Currently, LitElement is imported from unpkg.com this means without internet `button-entity-row` won't load and will show an error card. This also sometimes occurs with slow internet, showing an error card until LitElement finishes downloading. This change uses a local copy of it. The implementation is copied from other custom-cards that use LitElement e.g. `card-tools`.

TLDR; change LitElement to use the local copy instead of downloading it, also faster load times as only one copy of it will be fetched.