### PR TITLE
Add "unavailable" state for buttons

### DIFF
--- a/button-entity-row.js
+++ b/button-entity-row.js
@@ -36,6 +36,9 @@ class ButtonEntityRow extends LitElement {
       .button-inactive {
         color: var(--paper-item-icon-color);
       }
+      .button-unavailable {
+        color: var(--state-icon-unavailable-color);
+      }
     `
   }
 
@@ -205,6 +208,8 @@ class ButtonEntityRow extends LitElement {
         return "button-active"
       case "off":
         return "button-inactive"
+      case "unavailable":
+        return "button-unavailable"
       default:
         return "button-default"
     }


### PR DESCRIPTION
Show faded button icon and text if associated item is unavailable (offline)

In this example item «Гирлянда» is using standard Lovelace entity row. It's unavailable and so is faded.

Item «Звёзды» is using button-entity-row. It's unavailable as well, and after this patch it gets the same faded colour, showing that it's pointless to click on it to try changing its' state:

<img width="463" alt="sshot 2019-10-16 в 01 14 43" src="https://user-images.githubusercontent.com/1821846/66866275-650bcc80-efb2-11e9-9896-581fd3ff3c49.png">
